### PR TITLE
Permission Resource Aliases

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         php: ['8.0', '8.1']
-        laravel: ['9.2', '9.26']
+        laravel: ['9.2', '9.27']
         enum: ['3', '4']
     name: PHP ${{ matrix.php }} Laravel ${{ matrix.laravel }} Enum ${{ matrix.enum }}
     steps:

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # AppShell Changelog
 
+## Unreleased
+##### 2022-XX-YY
+
+- Added option to define ACL resource name aliases (eg 'master product' => 'product')
+
 ## 3.1.2
 ##### 2022-08-27
 

--- a/docs/acl.md
+++ b/docs/acl.md
@@ -156,7 +156,7 @@ and allows or denies (`abort(403)`) access to the route.
 
 As an example, the ACL middleware when applied to these routes will proceed like this:
 
-```
+```text
 URL /product/123/edit
  │
  └> Controller/Action = `ProductController@show`
@@ -175,7 +175,7 @@ URL /product/123/edit
      └──┘        
 ```
 
-```
+```text
 URL /product-types/123/edit
  │
  └> Controller/Action = `ProductTypeController@show`
@@ -201,6 +201,37 @@ and not the route definition, ie:
 
 - `ProductTypeController` -> the resource name will be `ProductType` regardless of how the route is defined;
 - `ProductTypeController::index` -> the action name will be `index` regardless of the route definition.
+
+### Resource Name Aliases
+
+Sometimes a permission should allow to additional resources.
+An example is that the `create products` permission allows creating both `product`
+and `master product` resources.
+
+To achieve this, set the key/value pairs within the `konekt.app_shell.acl.aliases` configuration:
+
+```php
+// config/concord.php
+return [
+    'modules' => [
+        Konekt\AppShell\Providers\ModuleServiceProvider::class => [
+            // ...
+            'acl' => [
+                'aliases' => [
+                    'master products' => 'products',
+                ],
+            ],
+            // ...
+```
+
+You can also define them using Laravel's built-in config helper:
+
+```php
+config(['konekt.app_shell.acl.aliases.master products' => 'products']);
+```
+
+The proper format is to use the plural variant for both the alias and the target, but
+if you pass singular resource names, the library will convert them.
 
 ## Creating CRUD with ACL
 

--- a/src/resources/config/box.php
+++ b/src/resources/config/box.php
@@ -10,7 +10,8 @@ return [
         Konekt\Acl\Providers\ModuleServiceProvider::class => []
     ],
     'acl' => [
-        'allow_action_as_verb' => false
+        'allow_action_as_verb' => false,
+        'aliases' => [],
     ],
     'event_listeners' => true,
     'menu' => [

--- a/tests/Unit/AclResourcePermissionMapperTest.php
+++ b/tests/Unit/AclResourcePermissionMapperTest.php
@@ -264,4 +264,61 @@ class AclResourcePermissionMapperTest extends TestCase
         $this->assertEquals('request approval for', $this->mapper->permissionVerbForAction('requestApprovalFor'));
         $this->assertEquals('reject publication of', $this->mapper->permissionVerbForAction('reject_publication_of'));
     }
+
+    /** @test */
+    public function resource_names_can_aliased()
+    {
+        $aliasedMapper = new ResourcePermissionMapper(['master products' => 'products']);
+
+        $this->assertEquals('create products', $aliasedMapper->permissionFor('master product', 'create'));
+    }
+
+    /** @test */
+    public function resource_names_aliases_can_be_set_from_the_config()
+    {
+        config(['konekt.app_shell.acl.aliases.simple products' => 'products']);
+
+        $this->assertEquals('create products', $this->mapper->permissionFor('simple product', 'create'));
+    }
+
+    /** @test */
+    public function resource_name_aliases_are_automatically_pluralized()
+    {
+        $aliasedMapper = new ResourcePermissionMapper([
+            'master product' => 'product',
+            'packages' => 'product',
+            'subscription' => 'products',
+        ]);
+
+        $this->assertEquals('edit products', $aliasedMapper->permissionFor('master product', 'edit'));
+        $this->assertEquals('edit products', $aliasedMapper->permissionFor('package', 'edit'));
+        $this->assertEquals('edit products', $aliasedMapper->permissionFor('subscription', 'edit'));
+    }
+
+    /** @test */
+    public function resource_name_aliases_are_automatically_pluralized_from_config()
+    {
+        config(['konekt.app_shell.acl.aliases' => [
+            'master product' => 'product',
+            'packages' => 'product',
+            'subscription' => 'products',
+        ]]);
+
+        $this->assertEquals('edit products', $this->mapper->permissionFor('master product', 'edit'));
+        $this->assertEquals('edit products', $this->mapper->permissionFor('package', 'edit'));
+        $this->assertEquals('edit products', $this->mapper->permissionFor('subscription', 'edit'));
+    }
+
+    /** @test */
+    public function resource_aliases_are_properly_normalized()
+    {
+        config(['konekt.app_shell.acl.aliases' => [
+            'master product' => 'product',
+        ]]);
+
+        $this->assertEquals('list products', $this->mapper->permissionFor('master product', 'index'));
+        $this->assertEquals('list products', $this->mapper->permissionFor('master-product', 'index'));
+        $this->assertEquals('list products', $this->mapper->permissionFor('master_product', 'index'));
+        $this->assertEquals('list products', $this->mapper->permissionFor('masterProduct', 'index'));
+    }
 }


### PR DESCRIPTION
This PR adds the option to define ACL resource name aliases (eg 'master product' => 'product')

