### PR TITLE
Fix Error: Unparenthesized `a ? b : c ? d : e`

### DIFF
--- a/src/resources/views/layouts/default/_js.blade.php
+++ b/src/resources/views/layouts/default/_js.blade.php
@@ -2,7 +2,7 @@
 <?php
     $cfg = config('konekt.app_shell.default_theme.custom_assets', []);
     $custom = $cfg['enabled'] ?? false;
-    $js = ($custom ? ($cfg['js_link'] ?? null) : null) ?: '/js/appshell.js';
+    $js = $custom ? ($cfg['js_link'] ?? '') : '/js/appshell.js';
     $helper = $cfg['helper'] ?? null;
     $helper = in_array($helper, ['mix', 'asset', null], true) ? $helper : null;
 ?>


### PR DESCRIPTION
Unparenthesized `a ? b : c ? d : e` is deprecated. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)`

Fix error: unparenthesized , compatible with php 7.4 && php 8.0 and above
