### PR TITLE
Swtiched default js to use javascript module

### DIFF
--- a/src/resources/views/layouts/default/_js.blade.php
+++ b/src/resources/views/layouts/default/_js.blade.php
@@ -9,5 +9,5 @@
 @if($custom)
     <script src="{{ null === $helper ? $js : $helper($js) }}"></script>
 @else
-    <script src="{{ $appshell->useMix ? mix('/js/appshell.js') : asset('/js/appshell.js') }}"></script>
+    <script type="module" src="{{ $appshell->useMix ? mix('/js/appshell.js') : asset('/js/appshell.js') }}"></script>
 @endif


### PR DESCRIPTION
fixed error for cannot use import statement outside a module, error occurs when trying to compile with inertiajs and laravel vite
